### PR TITLE
tutorial: disable root@'%'

### DIFF
--- a/docker/tutorial/docker-entrypoint-initdb.d/10_init.sql
+++ b/docker/tutorial/docker-entrypoint-initdb.d/10_init.sql
@@ -1,6 +1,10 @@
--- サンプルデータベースのインストール
-source employees.sql;
+-- disable root@'%'
+delete from mysql.user where user='root' and host='%';
+flush privileges;
 
 -- 演習用ユーザーの作成
 create user hello@'%' identified by 'world';
 grant select on employees.* to hello;
+
+-- サンプルデータベースのインストール
+source employees.sql;


### PR DESCRIPTION
ワルい新卒はいないと思っているけど念の為リモートからのrootアクセスを無効にしておく 😇 

#### Access deniedの確認

```sql
%%sql mysql+pymysql://root:mysql@10.0.1.100/employees
-- Here is a SQL comment.
-- TODO: RUN ME :-)
select count(1) from employees
```

```
(pymysql.err.OperationalError) (1045, "Access denied for user 'root'@'10.0.0.240' (using password: YES)")
(Background on this error at: http://sqlalche.me/e/e3q8)
Connection info needed in SQLAlchemy format, example:
               postgresql://username:password@hostname/dbname
               or an existing connection: dict_keys(['mysql+pymysql://hello:***@10.0.1.100/employees', 'mysql+pymysql://root:***@10.0.1.100/employees'])
```