### PR TITLE
インフラ周りのコマンドを整理する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,3 @@
-.PHONY: infra
-infra:
-	mkdir -p ./infra/tmp
-	aws s3 cp s3://mixi-db-training/config/keys/id_db_training.pub ./infra/tmp/
-	aws s3 cp s3://mixi-db-training/config/keys/hello.public.gpg ./infra/tmp/
-	docker build -t infra-tools ./docker/infra-tools
-	docker run \
-		-ti \
-		-v $(PWD):/app \
-		-v $(HOME)/.aws:/root/.aws \
-		-w /app \
-		infra-tools \
-		bash
-
-.PHONY: server/docker
-server/docker:
-	sudo apt update && sudo apt install -y docker.io
-	sudo usermod -a -G docker ubuntu
-	sudo service docker restart
-
-/swapfile:
-	sudo dd if=/dev/zero of=/swapfile bs=128M count=10
-	sudo chmod go-rwx /swapfile
-	sudo mkswap /swapfile
-	sudo swapon /swapfile
-
-.PHONY: server/db
-server/db: /swapfile
-	docker build -t tutorial ./docker/tutorial
-	docker run \
-		-d \
-		-v $(PWD)/docker/tutorial/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d \
-		-p 3306:3306 \
-		tutorial
-
-.PHONY: sshkey
-sshkey:
-	aws s3 cp s3://mixi-db-training/config/keys/id_db_training ~/.ssh/
-	chmod go-rwx ~/.ssh/id_db_training
-
 .PHONY: jupyter
 jupyter:
 	docker run \
@@ -59,17 +19,6 @@ isucon5q:
 	aws s3 cp s3://mixi-db-training/isucon5q/dump.sql.gz /tmp/dump.sql.gz
 	cat /tmp/dump.sql.gz | gunzip | mysql -uroot isucon5q
 
-.PHONY: benchapp
-benchapp:
-	docker build -t bench ./docker/bench
-	docker run \
-		-d \
-		--rm \
-		-v $(PWD)/docker/bench/webapp:/opt/webapp \
-		-w /opt/webapp \
-		-p 8080:8080 \
-		bench \
-		bundle exec rackup --host 0.0.0.0 --port 8080
 
 .PHONY: url
 url:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# 2019ProperTrainingDataBase
+## 2019年度新卒データベース研修
+
+### 演習環境の構築
+
+./infra ディレクトリの下にインフラ管理に必要なスクリプトなどが入っています。
+
+- ユーザー管理
+  - ./infra/variables.tf 内の `usernames` という項目を編集すると IAM ユーザーと対応する Cloud9 の開発環境が作成されます
+  - 注意: IAM ユーザー名は上で指定した名前に `db.` というプレフィックスが付いた状態で作成されます
+- インフラ管理ツール
+  - `make infra-tools` を実行すると必要な GPG 鍵やコマンドが入った Docker コンテナが立ち上がります
+- 実行手順
+  - infra-tools の起動
+  - terraform の実行
+    - terraform init => terraform apply
+  - Cloud9 の設定
+    - `python3 ./script/setup_cloud9.py`
+  - サーバーの設定
+    - `make server`

--- a/docker/infra-tools/Dockerfile
+++ b/docker/infra-tools/Dockerfile
@@ -7,9 +7,11 @@ RUN apt update && apt install -y \
   jq \
   vim \
   unzip \
-  curl
+  curl \
+  ssh
 
-RUN pip3 install awscli
+RUN pip3 install awscli boto3
+
 RUN mkdir -p /opt/terraform && \
   cd /opt/terraform && \
   curl -o terraform.zip https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip && \

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,0 +1,72 @@
+# 設定は ./infra/ec2.tf を参照
+SERVER_IP=10.0.1.100
+
+# terraformなどインフラ管理に必要なコマンドを実行するときに使う
+.PHONY: infra-tools
+infra-tools:
+	mkdir -p ./tmp
+	aws s3 cp s3://mixi-db-training/config/keys/id_db_training.pub ./tmp/
+	aws s3 cp s3://mixi-db-training/config/keys/hello.public.gpg ./tmp/
+	docker build -t infra-tools ../docker/infra-tools
+	docker run \
+		-ti \
+		-v $(PWD):/app \
+		-v $(HOME)/.aws:/root/.aws \
+		-w /app \
+		infra-tools \
+		bash
+
+~/.ssh/id_db_training:
+	aws s3 cp s3://mixi-db-training/config/keys/id_db_training ~/.ssh/
+	chmod go-rwx ~/.ssh/id_db_training
+
+# サーバーにログインする
+.PHONY: server/ssh
+server/ssh: ~/.ssh/id_db_training
+	ssh -i ~/.ssh/id_db_training ubuntu@$(SERVER_IP)
+
+# サーバーのセットアップ
+# Terraformの適用後に実行してください
+.PHONY: server
+server: ~/.ssh/id_db_training
+	scp -i ~/.ssh/id_db_training ./Makefile ubuntu@$(SERVER_IP):
+	scp -i ~/.ssh/id_db_training -r ../docker ubuntu@$(SERVER_IP):
+	ssh -i ~/.ssh/id_db_training ubuntu@$(SERVER_IP) make server/docker
+	ssh -i ~/.ssh/id_db_training ubuntu@$(SERVER_IP) make server/tutorial_db
+	ssh -i ~/.ssh/id_db_training ubuntu@$(SERVER_IP) make server/benchapp
+
+# サーバーにDockerをインストールする
+.PHONY: server/docker
+server/docker:
+	sudo apt update && sudo apt install -y docker.io
+	sudo usermod -a -G docker ubuntu
+	sudo service docker restart
+
+/swapfile:
+	sudo dd if=/dev/zero of=/swapfile bs=128M count=10
+	sudo chmod go-rwx /swapfile
+	sudo mkswap /swapfile
+	sudo swapon /swapfile
+
+# チュートリアル: Jupyter Notebookからのクエリを実行する MySQL サーバー
+.PHONY: server/tutorial_db
+server/tutorial_db: /swapfile
+	docker build -t tutorial_db ./docker/tutorial
+	docker run \
+		-d \
+		-v $(PWD)/docker/tutorial/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d \
+		-p 3306:3306 \
+		tutorial_db
+
+# インデックス演習: isucon5qのベンチマークを実行するためのWebアプリ
+.PHONY: server/benchapp
+server/benchapp:
+	docker build -t bench ./docker/bench
+	docker run \
+		-d \
+		--rm \
+		-v $(PWD)/docker/bench/webapp:/opt/webapp \
+		-w /opt/webapp \
+		-p 8080:8080 \
+		bench \
+		bundle exec rackup --host 0.0.0.0 --port 8080


### PR DESCRIPTION
- インフラの構築に使用するコマンドを別のMakefileに切り分けました
- チュートリアルなどで利用するMySQLサーバーやベンチマーク実行用のWebアプリのデプロイについては対象となるサーバーにscpでDockerfileなどを転送してMakefileを起点にdocker buildなどを実行するような形にしてあります