### PR TITLE
🤖 bench: 実行結果のslack通知

### DIFF
--- a/docker/bench/webapp/app.rb
+++ b/docker/bench/webapp/app.rb
@@ -1,7 +1,34 @@
 require 'sinatra'
+require 'net/http'
+require 'uri'
+require 'json'
+
+SLACK_WEBHOOK=ENV['SLACK_WEBHOOK']
+SLACK_CHANNEL=ENV['SLACK_CHANNEL']
+
 
 class App < Sinatra::Base
   get '/' do
-    `cd /opt/isucon5-qualify/bench && cat ../webapp/script/testsets/testsets.json | jq '.[0]' | gradle run -q -Pargs="net.isucon.isucon5q.bench.scenario.Isucon5Qualification #{request.ip}:8080" | ruby -rjson -r../eventapp/lib/score -e "r=JSON.parse(STDIN.read);puts Isucon5Portal::Score.calculate(r);puts r['responses'];r['violations'].each{|v| puts v['description']}" `
+    msg = `cd /opt/isucon5-qualify/bench && cat ../webapp/script/testsets/testsets.json | jq '.[0]' | gradle run -q -Pargs="net.isucon.isucon5q.bench.scenario.Isucon5Qualification #{request.ip}:8080" | ruby -rjson -r../eventapp/lib/score -e "r=JSON.parse(STDIN.read);puts Isucon5Portal::Score.calculate(r);puts r['responses'];r['violations'].each{|v| puts v['description']}" `
+
+    slack <<EOF
+benchmark result: `#{request.ip}` :runner:
+#{msg}
+EOF
+
+    msg
+  end
+
+  helpers do
+    def slack(msg)
+      uri = URI.parse(SLACK_WEBHOOK)
+      payload = {
+        text: msg,
+        channel: SLACK_CHANNEL,
+        username: '19新卒くん',
+        icon_emoji: ':innocent:'
+      }
+      Net::HTTP.post_form(uri, { payload: payload.to_json })
+    end
   end
 end

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -90,6 +90,7 @@ server/benchapp:
 		--rm \
 		-v $(PWD)/docker/bench/webapp:/opt/webapp \
 		-w /opt/webapp \
+		--env-file slack.env \
 		-p 28080:28080 \
 		bench \
 		bundle exec rackup --host 0.0.0.0 --port 28080


### PR DESCRIPTION
インデックス演習についてグルーヴ感を出すためにベンチマーク結果をSlackに通知します 

実行例

```
$ curl http://10.0.1.100:28080 
success
491.3
{"success"=>476, "redirect"=>153, "failure"=>1, "error"=>0, "exception"=>0}
```

通知サンプル

![](https://user-images.githubusercontent.com/28585440/55213688-715b5280-5237-11e9-9de2-d0cdf0546c1b.png)