### PR TITLE
🏀サーバーのインスタンスタイプを変更できるようにする

### DIFF
--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "judge_server" {
 
   associate_public_ip_address = true
   ami = "ami-0bbe6b35405ecebdb" # Ubuntu Server 18.04 LTS (HVM), SSD Volume Type (ami-0bbe6b35405ecebdb)
-  instance_type = "t2.nano"
+  instance_type = "t2.medium"
   key_name  = "${aws_key_pair.id_db_training.key_name}"
   subnet_id = "${aws_subnet.main_subnet_1b.id}"
   associate_public_ip_address = true

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "judge_server" {
 
   associate_public_ip_address = true
   ami = "ami-0bbe6b35405ecebdb" # Ubuntu Server 18.04 LTS (HVM), SSD Volume Type (ami-0bbe6b35405ecebdb)
-  instance_type = "t2.medium"
+  instance_type = "${var.SERVER_INSTANCE_TYPE}"
   key_name  = "${aws_key_pair.id_db_training.key_name}"
   subnet_id = "${aws_subnet.main_subnet_1b.id}"
   associate_public_ip_address = true

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -2,6 +2,10 @@ variable "pgp_public_key_path" {
   default = "./tmp/hello.public.gpg"
 }
 
+variable "SERVER_INSTANCE_TYPE" {
+  default = "t2.nano"
+}
+
 variable "usernames" {
   type = "list"
   default = [


### PR DESCRIPTION
環境変数にインスタンスタイプを指定すると変更できるようにします（未指定の場合は `t2.nano` ）

📝 実行手順（参考用）

```
~/environment/2019ProperTrainingDataBase/infra (change-instance-type) $ make infra-tools
root@4747d1b9bc03:/app# terraform init 
root@69a9a5c19fa3:/app# TF_VAR_SERVER_INSTANCE_TYPE=t2.medium terraform plan  

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_instance.judge_server
      instance_type: "t2.nano" => "t2.medium"


Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------
```